### PR TITLE
Remove capitalize from the callbacks

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,24 +1,21 @@
-const shuffle = require("lodash/shuffle");
-const capitalize = require("lodash/capitalize");
-const fetch = require("node-fetch");
+const shuffle = require('lodash/shuffle');
+const fetch = require('node-fetch');
 
 module.exports = async (req, res) => {
   const { query } = req;
 
-  const members = query.members.split(",");
+  const members = query.members.split(',');
 
-  const shuffled = shuffle(members)
-    .map((member) => capitalize(member))
-    .join(", ");
+  const shuffled = shuffle(members).join(', ');
 
   try {
     await fetch(query.url, {
-      method: "POST",
+      method: 'POST',
       body: JSON.stringify({
         r_list: shuffled,
       }),
     });
-    res.status(200).send("ok");
+    res.status(200).send('ok');
   } catch (error) {
     res.status(500).json({ error: error.message });
   }

--- a/api/on-call.js
+++ b/api/on-call.js
@@ -1,23 +1,21 @@
-const getWeek = require('date-fns/getWeek')
-const capitalize = require("lodash/capitalize");
-const fetch = require("node-fetch");
+const getWeek = require('date-fns/getWeek');
+const fetch = require('node-fetch');
 
 module.exports = async (req, res) => {
   const { query } = req;
 
-  const members = query.members.split(",")
-    .map((member) => capitalize(member));
+  const members = query.members.split(',');
   const week = getWeek(new Date(), { weekStartsOn: 1 });
   const index = week % members.length;
 
   try {
     await fetch(query.url, {
-      method: "POST",
+      method: 'POST',
       body: JSON.stringify({
         name: members[index],
       }),
     });
-    res.status(200).send("ok");
+    res.status(200).send('ok');
   } catch (error) {
     res.status(500).json({ error: error.message });
   }


### PR DESCRIPTION
In my opinion, it's easier to just make sure the endpoint is called with the right casing for the names.

Also, not having this allows us to pass slack user ids, which are all uppercase: `UL5PMPRBM`